### PR TITLE
Use `he` for robust HTML entity decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "bal-util": "~2.4.1",
     "extendr": "~2.1.0",
-    "highlight.js": "~8.0.0",
-    "ent": "~0.1.0"
+    "he": "~0.4.1",
+    "highlight.js": "~8.0.0"
   },
   "devDependencies": {
     "docpad": "6",

--- a/src/highlightjs.plugin.coffee
+++ b/src/highlightjs.plugin.coffee
@@ -65,7 +65,7 @@ module.exports = (BasePlugin) ->
 				# Correctly escape the source
 				if escape isnt true
 					# Unescape the output as highlightjs always escape
-					source = require('ent').decode(source)
+					source = require('he').decode(source)
 
 				# Transforms
 				for transform in transforms or []


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
