### PR TITLE
Update npm before testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # v1.3.14 February 6, 2014
 # https://github.com/bevry/base
 language: node_js
-install: "npm install; ./node_modules/.bin/cake install"
+install: "npm update -g npm; npm install; ./node_modules/.bin/cake install"
 before_script: "./node_modules/.bin/cake compile"
 script: "npm test"
 node_js:


### PR DESCRIPTION
This way, dependencies that use the `^x.y.z` syntax for their dependencies won’t break the Travis build anymore.
